### PR TITLE
TastingSheetオブジェクトの型を変更した

### DIFF
--- a/src/types/tasting_sheet/formItemClassProperty.ts
+++ b/src/types/tasting_sheet/formItemClassProperty.ts
@@ -1,5 +1,7 @@
+import WineColor from './wineColor'
+
 type FormItemClassProperty = {
-  color: string
+  color: WineColor
   name: string
   heading: string
   subHeading?: string

--- a/src/types/tasting_sheet/tastingSheet.ts
+++ b/src/types/tasting_sheet/tastingSheet.ts
@@ -2,11 +2,12 @@ import Appearance from './appearance/appearance'
 import Conclusion from './conclusion/conclusion'
 import Flavor from './flavor/flavor'
 import Taste from './taste/taste'
+import WineColor from './wineColor'
 
 type TastingSheet = {
   name?: string
   time: number | null
-  color: string
+  color: WineColor
   appearance: Appearance
   flavor: Flavor
   taste: Taste

--- a/src/types/tasting_sheet/wineColor.ts
+++ b/src/types/tasting_sheet/wineColor.ts
@@ -1,0 +1,3 @@
+type WineColor = 'white' | 'red'
+
+export default WineColor

--- a/src/utils/formItem.ts
+++ b/src/utils/formItem.ts
@@ -8,17 +8,19 @@ class FormItem {
   }
 
   #getLabels() {
-    if (this.#property.labels instanceof Array) return this.#property.labels
+    const { color, labels } = this.#property
+    if (labels instanceof Array) return labels
 
-    return this.#property.color === 'white' ? this.#property.labels.white : this.#property.labels.red
+    return color === 'white' ? labels.white : labels.red
   }
 
   get property() {
+    const { heading, name, subHeading } = this.#property
     return {
-      heading: this.#property.heading,
-      name: this.#property.name,
-      labels: this.#getLabels(),
-      subHeading: this.#property.subHeading
+      heading,
+      name,
+      subHeading,
+      labels: this.#getLabels()
     }
   }
 }


### PR DESCRIPTION
## What
- TastingSheetオブジェクトのcolorプロパティを変更した
- FormItemクラスのcolorプロパティを変更した
- FormItemクラスの実装を分割代入を使用することでリファクタリングした

## Why
- FormItemクラスの呼び出しをより安全に行うため