### PR TITLE
アカウント削除ボタンのが押された時にモーダルを表示するようにした

### DIFF
--- a/src/components/atoms/buttons/DeleteAccountButton.tsx
+++ b/src/components/atoms/buttons/DeleteAccountButton.tsx
@@ -1,0 +1,14 @@
+import { FC, memo } from 'react'
+import { useOnClickAuth } from '../../../hooks'
+
+const DeleteAccountButton: FC = memo(() => {
+  const { onClickDeleteAccount } = useOnClickAuth()
+
+  return (
+    <button type="button" onClick={onClickDeleteAccount} className="text-red-700">
+      削除
+    </button>
+  )
+})
+
+export default DeleteAccountButton

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -6,6 +6,7 @@ export { default as FormControllerButton } from './buttons/FormControllerButton'
 export { default as DeleteTastingSheetButton } from './buttons/DeleteTastingSheetButton'
 export { default as GoToTopPageButton } from './buttons/GoToTopPageButton'
 export { default as SignInAndPostButton } from './buttons/SignInAndPostButton'
+export { default as DeleteAccountButton } from './buttons/DeleteAccountButton'
 
 export { default as TastingSheetCheckBox } from './inputs/TastingSheetCheckBox'
 export { default as TastingSheetSelectBox } from './selects/TastingSheetSelectBox'

--- a/src/components/organisms/Footer.tsx
+++ b/src/components/organisms/Footer.tsx
@@ -1,12 +1,17 @@
 import { FC, memo } from 'react'
 
-import { useAuthContext, useCheckEditingForm, useOnClickAuth } from '../../hooks'
-import { FooterLink } from '../atoms'
+import { useAuthContext, useCheckEditingForm, useOnClickAuth, useOnClickOpenModal } from '../../hooks'
+import { DeleteAccountButton, FooterLink } from '../atoms'
 
 const Footer: FC = memo(() => {
   const { currentUser } = useAuthContext()
   const { isEditing } = useCheckEditingForm()
-  const { onClickSignOut, onClickDeleteAccount } = useOnClickAuth()
+  const { onClickSignOut } = useOnClickAuth()
+  const { onClickOpenModal } = useOnClickOpenModal({
+    text: '本当に削除してもよろしいですか？',
+    content: <DeleteAccountButton />,
+    closeText: 'いいえ'
+  })
 
   return (
     <footer className="flex flex-col items-center border-t border-gray-500 pt-4 mt-4">
@@ -23,7 +28,7 @@ const Footer: FC = memo(() => {
                 </button>
               </li>
               <li>
-                <button type="button" onClick={onClickDeleteAccount} className="text-red-700">
+                <button type="button" onClick={onClickOpenModal} className="text-red-700">
                   アカウント削除
                 </button>
               </li>


### PR DESCRIPTION
## What
- アカウント削除ボタンのコンポーネント化
- Footerコンポーネント内でモーダル表示関数の呼び出し

## Why
- アカウント削除前にユーザーへ確認を行うため
- UXの向上