### PR TITLE
ログアウトのローディングをローディングの分岐から取り除いて画面が切り替わらないエラーを修正した

### DIFF
--- a/src/hooks/auth/useOnClickAuth.ts
+++ b/src/hooks/auth/useOnClickAuth.ts
@@ -20,21 +20,21 @@ const useOnClickAuth = () => {
   const onClickSignOut = async () => {
     try {
       await signOut()
+      navigate('/')
     } catch (e) {
       if (e instanceof Error) throw e
     }
     showToast('ログアウトしました')
-    navigate('/')
   }
 
   const onClickDeleteAccount = async () => {
     try {
       await deleteAccount()
+      navigate('/')
     } catch (e) {
       if (e instanceof Error) throw e
     }
     showToast('アカウントを削除しました')
-    navigate('/')
   }
 
   return {

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -18,9 +18,9 @@ const AuthProvider: FC<ReactNodeChildren> = ({ children }) => {
   const [deleteAccountLoading, setDeleteAccountLoading] = useState(false)
   const [signInWithGoogle, , signInLoading, signInError] = useSignInWithGoogle(auth)
   const [authUser, authLoading, authError] = useAuthState(auth)
-  const [signOut, signOutLoading, signOutError] = useSignOut(auth)
+  const [signOut, , signOutError] = useSignOut(auth)
   const [deleteUser, deleteLoading, deleteError] = useDeleteUser(auth)
-  const loading = signInLoading || authLoading || signOutLoading || deleteLoading || deleteAccountLoading
+  const loading = signInLoading || authLoading || deleteLoading || deleteAccountLoading
   const error = signInError || authError || signOutError || deleteError
 
   useLayoutEffect(() => {


### PR DESCRIPTION
## What
- AuthProvider内、loadingの分岐条件からsignOutLoadingを取り除いた

## Why
- サインアウトにほぼ時間がかからないため、loadingに含めたままだとログアウト後のnavigateの画面切り替えがうまくいかないため