### PR TITLE
サインインユーザーしか閲覧できないページに認可を設定した

### DIFF
--- a/src/router/RouterConfig.tsx
+++ b/src/router/RouterConfig.tsx
@@ -1,13 +1,14 @@
 import { FC } from 'react'
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
 
-import { NewTastingSheetPage, SignedInWelcomePage, TastingSheetDetailsPage, WelcomePage } from '../components/pages'
+import { NewTastingSheetPage, TastingSheetDetailsPage } from '../components/pages'
 import { useAuthContext, useTastingSheetsContext } from '../hooks'
 import { ModalProvider } from '../providers'
 import SignedInWrapper from './SignedInWrapper'
+import WelcomePageWrapper from './WelcomePageWrapper'
 
 const RouterConfig: FC = () => {
-  const { currentUser, loading, error } = useAuthContext()
+  const { loading, error } = useAuthContext()
   const { requesting } = useTastingSheetsContext()
 
   if (error) return <p>やり直してください</p>
@@ -17,7 +18,7 @@ const RouterConfig: FC = () => {
     <BrowserRouter>
       <ModalProvider>
         <Routes>
-          <Route path="/" element={currentUser ? <SignedInWelcomePage /> : <WelcomePage />} />
+          <Route path="/" element={<WelcomePageWrapper />} />
           <Route path="/tasting_sheets">
             <Route path=":tastingSheetId" element={<SignedInWrapper page={<TastingSheetDetailsPage />} />} />
             <Route path="new" element={<NewTastingSheetPage />} />

--- a/src/router/RouterConfig.tsx
+++ b/src/router/RouterConfig.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import { NewTastingSheetPage, SignedInWelcomePage, TastingSheetDetailsPage, WelcomePage } from '../components/pages'
 import { useAuthContext, useTastingSheetsContext } from '../hooks'
 import { ModalProvider } from '../providers'
+import SignedInWrapper from './SignedInWrapper'
 
 const RouterConfig: FC = () => {
   const { currentUser, loading, error } = useAuthContext()
@@ -18,7 +19,7 @@ const RouterConfig: FC = () => {
         <Routes>
           <Route path="/" element={currentUser ? <SignedInWelcomePage /> : <WelcomePage />} />
           <Route path="/tasting_sheets">
-            <Route path=":tastingSheetId" element={<TastingSheetDetailsPage />} />
+            <Route path=":tastingSheetId" element={<SignedInWrapper page={<TastingSheetDetailsPage />} />} />
             <Route path="new" element={<NewTastingSheetPage />} />
           </Route>
         </Routes>

--- a/src/router/SignedInWrapper.tsx
+++ b/src/router/SignedInWrapper.tsx
@@ -1,0 +1,11 @@
+import { FC, ReactElement } from 'react'
+import { Navigate } from 'react-router-dom'
+import { useAuthContext } from '../hooks'
+
+const SignedInWrapper: FC<{ page: ReactElement }> = ({ page }) => {
+  const { currentUser } = useAuthContext()
+
+  return currentUser ? page : <Navigate to="/" />
+}
+
+export default SignedInWrapper

--- a/src/router/WelcomePageWrapper.tsx
+++ b/src/router/WelcomePageWrapper.tsx
@@ -1,0 +1,11 @@
+import { FC } from 'react'
+import { SignedInWelcomePage, WelcomePage } from '../components/pages'
+import { useAuthContext } from '../hooks'
+
+const WelcomePageWrapper: FC = () => {
+  const { currentUser } = useAuthContext()
+
+  return currentUser ? <SignedInWelcomePage /> : <WelcomePage />
+}
+
+export default WelcomePageWrapper

--- a/src/types/contexts/authContextType.ts
+++ b/src/types/contexts/authContextType.ts
@@ -2,8 +2,8 @@ import { AuthError, User, UserCredential } from 'firebase/auth'
 import { Dispatch, SetStateAction } from 'react'
 
 type AuthContextType = {
-  currentUser: User | null | undefined
-  setCurrentUser: Dispatch<SetStateAction<User | null | undefined>>
+  currentUser: User | null
+  setCurrentUser: Dispatch<SetStateAction<User | null>>
   signIn: () => Promise<UserCredential | undefined> | void
   signOut: () => Promise<boolean> | void
   deleteAccount: () => Promise<void> | void


### PR DESCRIPTION
## Issue
- https://github.com/yuma-matsui/tasting_note_front/issues/251

## What
- テイスティングシートの個別ページに認可の設定を加えた(非サインインユーザーが閲覧できないようにした)
- サインインの状態によって表示を切り替えるためのRouterコンポーネントを用意した
  - SignedInWrapper
  - WelcomePageWrapper

## Why
- 認可を与えて適切なページの表示を行うため