### PR TITLE
テイスティングシート名変更の処理を修正して不要なグローバルステートの呼び出しを取り除いた

### DIFF
--- a/src/components/atoms/buttons/GoToNewWinePageButton.tsx
+++ b/src/components/atoms/buttons/GoToNewWinePageButton.tsx
@@ -1,18 +1,14 @@
 import { FC, memo } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 
-import { useTastingSheetContext, useTastingSheetStateForWine } from '../../../hooks'
+import { useTastingSheetStateForWine } from '../../../hooks'
+import { TastingSheetApi } from '../../../types'
 
-const GoToNewWinePageButton: FC = memo(() => {
+const GoToNewWinePageButton: FC<{
+  tastingSheet: TastingSheetApi
+}> = memo(({ tastingSheet }) => {
   const navigate = useNavigate()
-  const { tastingSheetId } = useParams()
-  const { tastingSheet } = useTastingSheetContext()
-  const state = useTastingSheetStateForWine({
-    ...tastingSheet,
-    id: Number(tastingSheetId),
-    createdAt: '',
-    wine: null
-  })
+  const state = useTastingSheetStateForWine(tastingSheet)
 
   const onClick = () => navigate('/wines/new', { state })
 

--- a/src/components/molecules/forms/UpdateSheetNameForm.tsx
+++ b/src/components/molecules/forms/UpdateSheetNameForm.tsx
@@ -1,33 +1,18 @@
-import { Dispatch, FC, memo, SetStateAction, useRef } from 'react'
+import { FC, memo } from 'react'
 
-import { useTastingSheetForm, useToastContext, useUpdateTastingSheetName } from '../../../hooks'
-import { FormControllerButton, TastingSheetNameInput } from '../../atoms'
+import { useTastingSheetUpdateForm } from '../../../hooks'
+import { TastingSheetApi } from '../../../types'
+import { TastingSheetNameInput } from '../../atoms'
 
-const UpdateSheetNameForm: FC<{ setIsEditing: Dispatch<SetStateAction<boolean>> }> = memo(({ setIsEditing }) => {
-  const { register, errors, handleSubmit, onSubmit, isValid, isSubmitting, getValues } = useTastingSheetForm()
-  const { updateSheetName } = useUpdateTastingSheetName()
-  const { showToast } = useToastContext()
-
-  const updateRef = useRef<HTMLInputElement>(null)
-
-  const onClickUpdate = async () => {
-    updateRef.current?.click()
-
-    try {
-      await updateSheetName(getValues('tastingSheet'))
-    } catch (e) {
-      if (e instanceof Error) throw e
-    } finally {
-      setIsEditing(false)
-      showToast('テイスティグシート名を変更しました。')
-    }
-  }
+const UpdateSheetNameForm: FC<{
+  tastingSheet: TastingSheetApi
+}> = memo(({ tastingSheet }) => {
+  const { register, handleSubmit, isValid, isSubmitting, errors, onSubmit } = useTastingSheetUpdateForm(tastingSheet)
 
   return (
     <form className="flex" onSubmit={handleSubmit(onSubmit)}>
       <TastingSheetNameInput register={register} errors={errors} />
-      <FormControllerButton value="更新" disabled={!isValid || isSubmitting} onClick={onClickUpdate} />
-      <input type="submit" hidden ref={updateRef} />
+      <input type="submit" value="更新" disabled={isSubmitting || !isValid} className="btn" />
     </form>
   )
 })

--- a/src/components/molecules/titles/TastingSheetDetailsTitle.tsx
+++ b/src/components/molecules/titles/TastingSheetDetailsTitle.tsx
@@ -8,7 +8,7 @@ const TastingSheetDetailsTitle: FC<{ tastingSheet: TastingSheetApi }> = memo(({ 
   const onClick = () => setIsEditing(true)
 
   return isEditing ? (
-    <UpdateSheetNameForm setIsEditing={setIsEditing} />
+    <UpdateSheetNameForm tastingSheet={tastingSheet} />
   ) : (
     <h2>
       {tastingSheet.name}

--- a/src/components/pages/TastingSheetDetailsPage.tsx
+++ b/src/components/pages/TastingSheetDetailsPage.tsx
@@ -15,7 +15,7 @@ const TastingSheetDetailsPage: FC<{ tastingSheetId: number }> = memo(({ tastingS
     <DefaultLayout>
       <TastingSheetDetailsTitle tastingSheet={tastingSheet} />
       <TastingSheetDetailsTab tastingSheet={tastingSheet} />
-      {!tastingSheet.wine && <GoToNewWinePageButton />}
+      {!tastingSheet.wine && <GoToNewWinePageButton tastingSheet={tastingSheet} />}
       {tastingSheet.wine && (
         <>
           <div className="divider" />

--- a/src/hooks/api/useUpdateTastingSheetName.ts
+++ b/src/hooks/api/useUpdateTastingSheetName.ts
@@ -1,9 +1,9 @@
 import { useParams } from 'react-router-dom'
 
-import { TastingSheet, TastingSheetApi } from '../../types'
+import { TastingSheet } from '../../types'
 import useAuthContext from '../context/useAuthContext'
-import useTastingSheetContext from '../context/useTastingSheetContext'
 import useTastingSheetsContext from '../context/useTastingSheetsContext'
+import useToastContext from '../context/useToastContext'
 import useAxios from '../useAxios'
 
 const useUpdateTastingSheetName = () => {
@@ -11,26 +11,22 @@ const useUpdateTastingSheetName = () => {
   const target = Number(tastingSheetId)
 
   const { currentUser } = useAuthContext()
-  const { setTastingSheet } = useTastingSheetContext()
   const { setRequesting } = useTastingSheetsContext()
   const { client, getHeaders } = useAxios()
+  const { showToast } = useToastContext()
 
   const updateSheetName = async (tastingSheet: TastingSheet) => {
     if (!currentUser || Number.isNaN(target)) throw new Error('不正な呼び出し方です。')
     setRequesting(true)
 
     try {
-      const { data: tastingSheetApi } = await client.put<TastingSheetApi>(
-        `/tasting_sheets/${target}`,
-        tastingSheet,
-        await getHeaders(currentUser)
-      )
-      setTastingSheet(tastingSheetApi)
+      await client.put(`/tasting_sheets/${target}`, tastingSheet, await getHeaders(currentUser))
     } catch (e) {
       if (e instanceof Error) throw e
     } finally {
       setRequesting(false)
     }
+    showToast('シート名を変更しました')
   }
 
   return {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export { default as useDetailsTabItems } from './tasting_sheet/useDetailsTabItems'
 export { default as useTastingSheetForm } from './tasting_sheet/useTastingSheetForm'
+export { default as useTastingSheetUpdateForm } from './tasting_sheet/useTastingSheetUpdateForm'
 export { default as useTastingSheetInputsAttributes } from './tasting_sheet/useTastingSheetInputAttributes'
 export { default as useTastingSheetLabels } from './tasting_sheet/useTastingSheetLabels'
 export { default as useMultiStepForm } from './tasting_sheet/useMultiStepForm'

--- a/src/hooks/tasting_sheet/useTastingSheetUpdateForm.ts
+++ b/src/hooks/tasting_sheet/useTastingSheetUpdateForm.ts
@@ -1,0 +1,41 @@
+import { SubmitHandler, useForm } from 'react-hook-form'
+
+import { TastingSheetApi, TastingSheetFormState } from '../../types'
+import useUpdateTastingSheetName from '../api/useUpdateTastingSheetName'
+
+const useTastingSheetUpdateForm = (tastingSheet: TastingSheetApi) => {
+  const { updateSheetName } = useUpdateTastingSheetName()
+  const {
+    register,
+    handleSubmit,
+    formState: {
+      isValid,
+      isSubmitting,
+      errors: { tastingSheet: errors }
+    }
+  } = useForm<TastingSheetFormState>({
+    defaultValues: {
+      tastingSheet
+    },
+    mode: 'onChange'
+  })
+
+  const onSubmit: SubmitHandler<TastingSheetFormState> = async (data) => {
+    try {
+      await updateSheetName(data.tastingSheet)
+    } catch (e) {
+      if (e instanceof Error) throw e
+    }
+  }
+
+  return {
+    register,
+    handleSubmit,
+    isValid,
+    isSubmitting,
+    errors,
+    onSubmit
+  }
+}
+
+export default useTastingSheetUpdateForm


### PR DESCRIPTION
## Issue
- https://github.com/yuma-matsui/tasting_note_front/issues/275

## What
- テイスティングシート名更新用フォームのhooksを実装した
- テイスティングシート更新時に呼び出していたグローバルステートを取り除いた

## Why
- 不要にグローバルステートを呼び出すことで新規作成処理にバグが生じていたため