### PR TITLE
ヘッダーとテイスティングシート新規作成の設定フォームにスタイルを当てた

### DIFF
--- a/src/components/atoms/buttons/DeleteAccountButton.tsx
+++ b/src/components/atoms/buttons/DeleteAccountButton.tsx
@@ -1,4 +1,5 @@
 import { FC, memo } from 'react'
+
 import { useOnClickAuth, useOnClickOpenModal } from '../../../hooks'
 
 const DeleteAccountButton: FC = memo(() => {
@@ -6,14 +7,14 @@ const DeleteAccountButton: FC = memo(() => {
   const { onClickOpenModal } = useOnClickOpenModal({
     text: '本当に削除してもよろしいですか？',
     rightButton: (
-      <button type="button" onClick={onClickDeleteAccount} className="text-red-700">
+      <button type="button" onClick={onClickDeleteAccount} className="text-theme-red">
         削除
       </button>
     )
   })
 
   return (
-    <button type="button" onClick={onClickOpenModal} className="text-red-700">
+    <button type="button" onClick={onClickOpenModal} className="text-theme-pink">
       アカウント削除
     </button>
   )

--- a/src/components/atoms/inputs/TastingSheetCheckBox.tsx
+++ b/src/components/atoms/inputs/TastingSheetCheckBox.tsx
@@ -1,25 +1,33 @@
 import { FC, memo } from 'react'
 
-import { useTastingSheetForm, useTastingSheetInputsAttributes } from '../../../hooks'
+import {
+  useGetCheckBoxClassName,
+  useGetRadioOrCheckBoxType,
+  useTastingSheetForm,
+  useTastingSheetInputsAttributes
+} from '../../../hooks'
 import { TastingSheetCheckBoxProps } from '../../../types'
 
 const TastingSheetCheckBox: FC<TastingSheetCheckBoxProps> = memo(
   ({ id, name, value, disabled = false, register, label }) => {
     const { getValues } = useTastingSheetForm()
     const { isMultipleInputs, getValidationMethod } = useTastingSheetInputsAttributes()
+    const { type } = useGetRadioOrCheckBoxType(isMultipleInputs(getValues(name)))
+    const className = useGetCheckBoxClassName(type)
 
     return (
-      <label htmlFor={id}>
+      <label htmlFor={id} className="label cursor-pointer">
         <input
-          type={isMultipleInputs(getValues(name)) ? 'checkbox' : 'radio'}
+          type={type}
           id={id}
           value={value}
           disabled={disabled}
           {...register(name, {
             validate: getValidationMethod(getValues(name))
           })}
+          className={className}
         />
-        {label ?? value}
+        <span className="label-text text-base ml-2">{label ?? value}</span>
       </label>
     )
   }

--- a/src/components/atoms/inputs/TastingSheetCheckBox.tsx
+++ b/src/components/atoms/inputs/TastingSheetCheckBox.tsx
@@ -27,7 +27,7 @@ const TastingSheetCheckBox: FC<TastingSheetCheckBoxProps> = memo(
           })}
           className={className}
         />
-        <span className="label-text text-base ml-2">{label ?? value}</span>
+        <span className="label-text ml-2">{label ?? value}</span>
       </label>
     )
   }

--- a/src/components/atoms/inputs/TastingSheetNameInput.tsx
+++ b/src/components/atoms/inputs/TastingSheetNameInput.tsx
@@ -4,7 +4,7 @@ import { FormRegisterAndErrors } from '../../../types'
 const TastingSheetNameInput: FC<FormRegisterAndErrors> = memo(({ register, errors }) => (
   <div className="form-control w-full max-w-xs my-6">
     <label htmlFor="name" className="label flex flex-col items-center">
-      <span className="label-text mb-2 leading-6 text-base">シート名</span>
+      <span className="label-text mb-2 leading-6">シート名</span>
       <input
         type="text"
         id="name"

--- a/src/components/atoms/inputs/TastingSheetNameInput.tsx
+++ b/src/components/atoms/inputs/TastingSheetNameInput.tsx
@@ -2,14 +2,20 @@ import { FC, memo } from 'react'
 import { FormRegisterAndErrors } from '../../../types'
 
 const TastingSheetNameInput: FC<FormRegisterAndErrors> = memo(({ register, errors }) => (
-  <div>
-    <label htmlFor="name">
-      シート名
-      <input type="text" id="name" className="block" {...register('tastingSheet.name', { required: true })} />
+  <div className="form-control w-full max-w-xs my-6">
+    <label htmlFor="name" className="label flex flex-col items-center">
+      <span className="label-text mb-2 leading-6">シート名</span>
+      <input
+        type="text"
+        id="name"
+        placeholder="例：ボルドー/赤"
+        className="input input-bordered border-gray-700 w-full max-w-xs h-8"
+        {...register('tastingSheet.name', { required: true })}
+      />
     </label>
     {errors && (
       <p>
-        <span>シート名を入力してください</span>
+        <span className="text-theme-pink">シート名を入力してください</span>
       </p>
     )}
   </div>

--- a/src/components/atoms/inputs/TastingSheetNameInput.tsx
+++ b/src/components/atoms/inputs/TastingSheetNameInput.tsx
@@ -4,7 +4,7 @@ import { FormRegisterAndErrors } from '../../../types'
 const TastingSheetNameInput: FC<FormRegisterAndErrors> = memo(({ register, errors }) => (
   <div className="form-control w-full max-w-xs my-6">
     <label htmlFor="name" className="label flex flex-col items-center">
-      <span className="label-text mb-2 leading-6">シート名</span>
+      <span className="label-text mb-2 leading-6 text-base">シート名</span>
       <input
         type="text"
         id="name"

--- a/src/components/atoms/selects/TastingSheetSelectBox.tsx
+++ b/src/components/atoms/selects/TastingSheetSelectBox.tsx
@@ -4,7 +4,7 @@ import { TastingSheetSelectBoxProps } from '../../../types'
 
 const TastingSheetSelectBox: FC<TastingSheetSelectBoxProps> = memo(({ id, register, name, options, label }) => (
   <label htmlFor={id} className="mb-6 label flex flex-col">
-    <span className="label-text mb-2 leading-6 text-base">{label}</span>
+    <span className="label-text mb-2 leading-6">{label}</span>
     <select
       id={id}
       {...register(name, { required: true })}

--- a/src/components/atoms/selects/TastingSheetSelectBox.tsx
+++ b/src/components/atoms/selects/TastingSheetSelectBox.tsx
@@ -3,9 +3,14 @@ import { FC, memo } from 'react'
 import { TastingSheetSelectBoxProps } from '../../../types'
 
 const TastingSheetSelectBox: FC<TastingSheetSelectBoxProps> = memo(({ id, register, name, options, label }) => (
-  <label htmlFor={id}>
-    {label}
-    <select id={id} {...register(name, { required: true })} className="block">
+  <label htmlFor={id} className="mb-6 label flex flex-col">
+    <span className="label-text mb-2 leading-6">{label}</span>
+    <select
+      id={id}
+      {...register(name, { required: true })}
+      className="select select-bordered w-full max-w-xs border-black select-sm"
+    >
+      <option disabled>{`${label}を選択してください`}</option>
       {options.map((option) => (
         <option key={option} value={option}>
           {option}

--- a/src/components/atoms/selects/TastingSheetSelectBox.tsx
+++ b/src/components/atoms/selects/TastingSheetSelectBox.tsx
@@ -4,7 +4,7 @@ import { TastingSheetSelectBoxProps } from '../../../types'
 
 const TastingSheetSelectBox: FC<TastingSheetSelectBoxProps> = memo(({ id, register, name, options, label }) => (
   <label htmlFor={id} className="mb-6 label flex flex-col">
-    <span className="label-text mb-2 leading-6">{label}</span>
+    <span className="label-text mb-2 leading-6 text-base">{label}</span>
     <select
       id={id}
       {...register(name, { required: true })}

--- a/src/components/molecules/WineColorRadios.tsx
+++ b/src/components/molecules/WineColorRadios.tsx
@@ -1,0 +1,28 @@
+import { FC, memo } from 'react'
+
+import { UseFormRegister } from 'react-hook-form'
+import { TastingSheetFormState } from '../../types'
+import { WINE_COLORS } from '../../assets'
+import { TastingSheetCheckBox } from '../atoms'
+
+const WineColorRadios: FC<{
+  register: UseFormRegister<TastingSheetFormState>
+}> = memo(({ register }) => (
+  <div className="flex flex-col items-center w-full mb-6">
+    <span className="mb-2">ワインの色</span>
+    <div className="flex justify-between w-1/2">
+      {WINE_COLORS.map((color) => (
+        <TastingSheetCheckBox
+          key={color}
+          id={color}
+          value={color}
+          register={register}
+          name="tastingSheet.color"
+          label={color === 'white' ? '白' : '赤'}
+        />
+      ))}
+    </div>
+  </div>
+))
+
+export default WineColorRadios

--- a/src/components/molecules/forms/NewTastingSheetSettingForm.tsx
+++ b/src/components/molecules/forms/NewTastingSheetSettingForm.tsx
@@ -13,7 +13,7 @@ const NewTastingSheetSettingForm: FC<FormRegisterAndErrors> = memo(({ register, 
       register={register}
       name="tastingSheet.time"
       options={TASTING_TIME}
-      label="テイスティング時間"
+      label="テイスティング時間（分）"
     />
     <div>
       <p>ワインの色</p>

--- a/src/components/molecules/forms/NewTastingSheetSettingForm.tsx
+++ b/src/components/molecules/forms/NewTastingSheetSettingForm.tsx
@@ -1,9 +1,10 @@
 import { FC, memo } from 'react'
 
-import { TASTING_TIME, WINE_COLORS } from '../../../assets'
+import { TASTING_TIME } from '../../../assets'
 import { FormRegisterAndErrors } from '../../../types'
-import { TastingSheetCheckBox, TastingSheetNameInput, TastingSheetSelectBox } from '../../atoms'
+import { TastingSheetNameInput, TastingSheetSelectBox } from '../../atoms'
 import { TastingSheetFormWrapper } from '../../templates'
+import WineColorRadios from '../WineColorRadios'
 
 const NewTastingSheetSettingForm: FC<FormRegisterAndErrors> = memo(({ register, errors }) => (
   <TastingSheetFormWrapper title="setting">
@@ -15,19 +16,7 @@ const NewTastingSheetSettingForm: FC<FormRegisterAndErrors> = memo(({ register, 
       options={TASTING_TIME}
       label="テイスティング時間（分）"
     />
-    <div>
-      <p>ワインの色</p>
-      {WINE_COLORS.map((color) => (
-        <TastingSheetCheckBox
-          key={color}
-          id={color}
-          value={color}
-          register={register}
-          name="tastingSheet.color"
-          label={color === 'white' ? '白' : '赤'}
-        />
-      ))}
-    </div>
+    <WineColorRadios register={register} />
   </TastingSheetFormWrapper>
 ))
 

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -13,6 +13,7 @@ export { default as StepsBar } from './StepsBar'
 export { default as TastingSheetCard } from './TastingSheetCard'
 export { default as PaginationButtons } from './PaginationButtons'
 export { default as SearchColorRadios } from './SearchColorRadios'
+export { default as WineColorRadios } from './WineColorRadios'
 
 export { default as WelcomePageAboutSection } from './sections/WelcomePageAboutSection'
 export { default as WelcomePageWithRegistrationSection } from './sections/WelcomePageWithRegistrationSection'

--- a/src/components/molecules/logos/HeaderLogo.tsx
+++ b/src/components/molecules/logos/HeaderLogo.tsx
@@ -3,7 +3,7 @@ import { FC, memo } from 'react'
 import logo from '../../../assets/images/logo.png'
 
 const HeaderLogo: FC = memo(() => (
-  <div className="flex">
+  <div className="flex px-5">
     <img src={logo} alt="Header Logo" className="w-14 h-14" />
     <div className="ml-2 flex flex-col justify-between">
       <h2 className="text-theme-red text-2xl tracking-wide font-semibold text-left">Tasting Note</h2>

--- a/src/components/molecules/logos/HeaderLogo.tsx
+++ b/src/components/molecules/logos/HeaderLogo.tsx
@@ -3,11 +3,11 @@ import { FC, memo } from 'react'
 import logo from '../../../assets/images/logo.png'
 
 const HeaderLogo: FC = memo(() => (
-  <div className="flex cursor-pointer">
-    <img src={logo} alt="Header Logo" className="w-24 h-24" />
-    <div>
-      <h2>Tasting Note</h2>
-      <p>テイスティングを記録してソムリエに</p>
+  <div className="flex">
+    <img src={logo} alt="Header Logo" className="w-14 h-14" />
+    <div className="ml-2 flex flex-col justify-between">
+      <h2 className="text-theme-red text-2xl tracking-wide font-semibold text-left">Tasting Note</h2>
+      <p className="leading-5">テイスティングを記録してソムリエに</p>
     </div>
   </div>
 ))

--- a/src/components/molecules/titles/TopPageTitle.tsx
+++ b/src/components/molecules/titles/TopPageTitle.tsx
@@ -7,7 +7,7 @@ const TopPageTitle: FC = memo(() => (
     <img className="w-16 h-16" src={logo} alt="logo" />
     <div className="ml-2 flex flex-col justify-between">
       <h1 className="text-theme-red font-bold text-3xl tracking-wider">Tasting Note</h1>
-      <p className="mt-1 leading-5">テイスティングを記録してソムリエに</p>
+      <p className="leading-5">テイスティングを記録してソムリエに</p>
     </div>
   </div>
 ))

--- a/src/components/organisms/Footer.tsx
+++ b/src/components/organisms/Footer.tsx
@@ -8,7 +8,7 @@ const Footer: FC = memo(() => {
   const { isEditing } = useCheckEditingForm()
 
   return (
-    <footer className="mt-6 sub-wrapper">
+    <footer className="mt-6 sub-wrapper px-5 md:px-0">
       <div className="flex flex-col items-center pt-4 border-t drop-shadow-md">
         <FooterLink />
         {!isEditing && <FooterNavigation />}

--- a/src/components/organisms/Footer.tsx
+++ b/src/components/organisms/Footer.tsx
@@ -8,8 +8,8 @@ const Footer: FC = memo(() => {
   const { isEditing } = useCheckEditingForm()
 
   return (
-    <footer className="mt-6 w-full md:w-96">
-      <div className="flex flex-col items-center pt-4 border-t">
+    <footer className="mt-6 sub-wrapper">
+      <div className="flex flex-col items-center pt-4 border-t drop-shadow-md">
         <FooterLink />
         {!isEditing && <FooterNavigation />}
         <p className="text-gray-700">&copy;2023 yuma-matsui</p>

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -3,7 +3,7 @@ import { FC, memo } from 'react'
 import { HeaderLink } from '../atoms'
 
 const Header: FC = memo(() => (
-  <header className="flex flex-col items-center border-b border-solid border-red-800">
+  <header className="border-b border-b-theme-red drop-shadow-md mb-8 pb-2 sub-wrapper">
     <HeaderLink />
   </header>
 ))

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -3,7 +3,7 @@ import { FC, memo } from 'react'
 import { HeaderLink } from '../atoms'
 
 const Header: FC = memo(() => (
-  <header className="border-b border-b-theme-red drop-shadow-md mb-8 pb-2 sub-wrapper">
+  <header className="border-b border-b-theme-red drop-shadow-md mb-8 py-2 sub-wrapper">
     <HeaderLink />
   </header>
 ))

--- a/src/components/pages/NewTastingSheetPage.tsx
+++ b/src/components/pages/NewTastingSheetPage.tsx
@@ -30,7 +30,7 @@ const NewTastingSheetPage: FC = memo(() => {
 
   return (
     <DefaultLayout>
-      <form onSubmit={handleSubmit(onSubmit)}>
+      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col items-center">
         {!isFirstStep && <TastingSheetTimer tastingSheet={tastingSheet} isLastStep={isLastStep} />}
         {!isFirstStep && !isLastStep && <StepsBar currentStepIndex={currentStepIndex} />}
         <FormController

--- a/src/components/pages/WelcomePage.tsx
+++ b/src/components/pages/WelcomePage.tsx
@@ -5,7 +5,7 @@ import { TopPageTitle, WelcomePageAboutSection, WelcomePageWithRegistrationSecti
 import { Footer } from '../organisms'
 
 const WelcomePage: FC = memo(() => (
-  <div className="px-5 main-wrapper">
+  <div className="main-wrapper">
     <TopPageTitle />
     <WelcomePageAboutSection />
     <div className="demo-img-wrapper bg-gray-700 text-white mb-4">サービスのデモ画像配置予定</div>

--- a/src/components/pages/WelcomePage.tsx
+++ b/src/components/pages/WelcomePage.tsx
@@ -5,12 +5,12 @@ import { TopPageTitle, WelcomePageAboutSection, WelcomePageWithRegistrationSecti
 import { Footer } from '../organisms'
 
 const WelcomePage: FC = memo(() => (
-  <div className="px-5 w-full md:w-96 mx-auto">
+  <div className="px-5 main-wrapper">
     <TopPageTitle />
     <WelcomePageAboutSection />
-    <div className="h-96 w-full md:w-96 bg-gray-700 text-white mb-4">サービスのデモ画像配置予定</div>
+    <div className="demo-img-wrapper bg-gray-700 text-white mb-4">サービスのデモ画像配置予定</div>
     <WelcomePageWithRegistrationSection />
-    <div className="w-full md:w-96 flex justify-between">
+    <div className="sub-wrapper flex justify-between">
       <StartTastingButton />
       <SignInButton />
     </div>

--- a/src/components/templates/DefaultLayout.tsx
+++ b/src/components/templates/DefaultLayout.tsx
@@ -6,10 +6,8 @@ import { Footer, Header } from '../organisms'
 const DefaultLayout: FC<ReactNodeChildren> = memo(({ children }) => (
   <>
     <Header />
-    <div className="main-wrapper">
-      {children}
-      <Footer />
-    </div>
+    <div className="main-wrapper">{children}</div>
+    <Footer />
   </>
 ))
 

--- a/src/components/templates/DefaultLayout.tsx
+++ b/src/components/templates/DefaultLayout.tsx
@@ -6,8 +6,10 @@ import { Footer, Header } from '../organisms'
 const DefaultLayout: FC<ReactNodeChildren> = memo(({ children }) => (
   <>
     <Header />
-    {children}
-    <Footer />
+    <div className="main-wrapper">
+      {children}
+      <Footer />
+    </div>
   </>
 ))
 

--- a/src/components/templates/TastingSheetFormWrapper.tsx
+++ b/src/components/templates/TastingSheetFormWrapper.tsx
@@ -9,7 +9,7 @@ const TastingSheetFormWrapper: FC<FormWrapperProps> = memo(({ title, children })
 
   return (
     <>
-      {isEditing && <h2>{formTitleFormat(title)}</h2>}
+      {isEditing && <h2 className="font-semibold font-xl text-center">{formTitleFormat(title)}</h2>}
       {children}
     </>
   )

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -10,6 +10,8 @@ export { default as useTastingSheetCardColor } from './tasting_sheet/useTastingS
 export { default as useTastingSheetStateForWine } from './tasting_sheet/useTastingSheetStateForWine'
 export { default as useTastingSheetSearchForm } from './tasting_sheet/useTastingSheetSearchForm'
 export { default as useFilteredTastingSheets } from './tasting_sheet/useFilteredTastingSheets'
+export { default as useGetRadioOrCheckBoxType } from './tasting_sheet/useGetRadioOrCheckBoxType'
+export { default as useGetCheckBoxClassName } from './tasting_sheet/useGetCheckBoxClassName'
 
 export { default as usePostTastingSheet } from './api/usePostTastingSheet'
 export { default as useFetchTastingSheets } from './api/useFetchTastingSheets'

--- a/src/hooks/tasting_sheet/useGetCheckBoxClassName.ts
+++ b/src/hooks/tasting_sheet/useGetCheckBoxClassName.ts
@@ -1,0 +1,4 @@
+const useGetCheckBoxClassName = (type: string) =>
+  type === 'checkbox' ? 'checkbox checkbox-sm checkbox-primary' : 'radio radio-sm radio-primary'
+
+export default useGetCheckBoxClassName

--- a/src/hooks/tasting_sheet/useGetRadioOrCheckBoxType.ts
+++ b/src/hooks/tasting_sheet/useGetRadioOrCheckBoxType.ts
@@ -1,0 +1,9 @@
+const useGetRadioOrCheckBoxClassName = (isCheckBox: boolean) => {
+  const type = isCheckBox ? 'checkbox' : 'radio'
+
+  return {
+    type
+  }
+}
+
+export default useGetRadioOrCheckBoxClassName

--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,18 @@
   @apply rounded-full shadow-md px-8 py-2 border-transparent text-white cursor-pointer
 }
 
+.sub-wrapper {
+  @apply w-full md:w-96
+}
+
+.main-wrapper {
+  @apply sub-wrapper mx-auto
+}
+
+.demo-img-wrapper {
+  @apply sub-wrapper h-96
+}
+
 section {
   @apply mb-4
 }

--- a/src/index.css
+++ b/src/index.css
@@ -27,3 +27,7 @@ section {
 .label {
   @apply justify-start
 }
+
+.label-text {
+  @apply text-base
+}

--- a/src/index.css
+++ b/src/index.css
@@ -9,11 +9,11 @@
 }
 
 .sub-wrapper {
-  @apply w-full md:w-96
+  @apply w-full md:w-96 mx-auto
 }
 
 .main-wrapper {
-  @apply sub-wrapper mx-auto
+  @apply sub-wrapper px-5
 }
 
 .demo-img-wrapper {

--- a/src/index.css
+++ b/src/index.css
@@ -23,3 +23,7 @@
 section {
   @apply mb-4
 }
+
+.label {
+  @apply justify-start
+}

--- a/src/utils/__test__/formTitleFormat.test.ts
+++ b/src/utils/__test__/formTitleFormat.test.ts
@@ -7,7 +7,7 @@ describe('formTitleFormat', () => {
     ['flavor', '香り'],
     ['taste', '味わい'],
     ['conclusion', 'まとめ'],
-    ['setting', '設定'],
+    ['setting', 'テイスティングシートの設定'],
     ['confirmation', 'あなたの回答']
   ]
   it.each(testCases)('%sを引数に与えた場合%sが返る', (input, expected) => {

--- a/src/utils/formTitleFormat.ts
+++ b/src/utils/formTitleFormat.ts
@@ -11,7 +11,7 @@ const formTitleFormat = (type: TastingSheetFormType) => {
     case 'conclusion':
       return 'まとめ'
     case 'setting':
-      return '設定'
+      return 'テイスティングシートの設定'
     case 'confirmation':
       return 'あなたの回答'
     default:

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,7 +17,14 @@ module.exports = {
     }
   },
   daisyui: {
-    themes: false
+    themes: [
+      {
+        light: {
+          ...require('daisyui/src/colors/themes')['[data-theme=light]'],
+          primary: '#3b82f6'
+        }
+      }
+    ]
   },
   plugins: [require('daisyui')]
 }


### PR DESCRIPTION
## Issue
- https://github.com/yuma-matsui/tasting_note_front/issues/42

## What
- デザインを当てた
  - ヘッダ
  - テイスティングシート新規作成ページの設定フォーム
    - シート名のインプット
    - セレクトボックス
    - チェックボックス
  - daisyUIのテーマカラーを拡張した

## Why
- ユーザビリティを向上させるため
