### PR TITLE
error boundaryの呼び出し位置を変更してモーダル内からshow boundaryを呼び出せるようにした

### DIFF
--- a/src/router/RouterConfig.tsx
+++ b/src/router/RouterConfig.tsx
@@ -27,8 +27,8 @@ const RouterConfig: FC = () => {
 
   return (
     <BrowserRouter>
-      <ModalProvider>
-        <ErrorBoundary FallbackComponent={ErrorFallbackForApi}>
+      <ErrorBoundary FallbackComponent={ErrorFallbackForApi}>
+        <ModalProvider>
           <Routes>
             <Route path="/" element={<WelcomePageWrapper />} />
             <Route path="/pp" element={<PrivacyPolicyPage />} />
@@ -47,8 +47,8 @@ const RouterConfig: FC = () => {
             </Route>
             <Route path="*" element={<Error404Page />} />
           </Routes>
-        </ErrorBoundary>
-      </ModalProvider>
+        </ModalProvider>
+      </ErrorBoundary>
     </BrowserRouter>
   )
 }


### PR DESCRIPTION
## What
- ErrorBoundaryコンポーネントの呼び出し位置を変更した

## Why
- ModalProviderよりも高い位置で呼び出さないとエラーが発生してしまうため