### PR TITLE
サインイン関数をリファクタリングした

### DIFF
--- a/src/hooks/auth/useOnClickAuth.ts
+++ b/src/hooks/auth/useOnClickAuth.ts
@@ -12,9 +12,13 @@ const useOnClickAuth = () => {
   const { showToast } = useToastContext()
   const navigate = useNavigate()
 
-  const onClickSignIn = () => {
-    signIn()
-    window.localStorage.setItem(SIGNED_IN_KEY, 'signedIn')
+  const onClickSignIn = async () => {
+    try {
+      await signIn()
+      window.localStorage.setItem(SIGNED_IN_KEY, 'signedIn')
+    } catch (e) {
+      if (e instanceof Error) showBoundary(e)
+    }
   }
 
   const onClickSignOut = async () => {

--- a/src/hooks/tasting_sheet/useSetSheetToLocalStorageAndSignIn.ts
+++ b/src/hooks/tasting_sheet/useSetSheetToLocalStorageAndSignIn.ts
@@ -1,13 +1,20 @@
+import { useErrorBoundary } from 'react-error-boundary'
+
 import { TastingSheet } from '../../types'
 import { TASTING_SHEET_KEY } from '../../utils'
 import useAuthContext from '../context/useAuthContext'
 
 const useSetSheetToLocalStorageAndSignIn = () => {
   const { signIn } = useAuthContext()
+  const { showBoundary } = useErrorBoundary()
 
-  const setTastingSheetAndSignIn = (tastingSheet: TastingSheet) => {
-    window.localStorage.setItem(TASTING_SHEET_KEY, JSON.stringify(tastingSheet))
-    signIn()
+  const setTastingSheetAndSignIn = async (tastingSheet: TastingSheet) => {
+    try {
+      window.localStorage.setItem(TASTING_SHEET_KEY, JSON.stringify(tastingSheet))
+      await signIn()
+    } catch (e) {
+      if (e instanceof Error) showBoundary(e)
+    }
   }
 
   return {

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -1,4 +1,4 @@
-import { browserLocalPersistence, setPersistence, signInWithRedirect, GoogleAuthProvider } from 'firebase/auth'
+import { signInWithRedirect, GoogleAuthProvider } from 'firebase/auth'
 import { FC, useCallback, useMemo, useState } from 'react'
 import { useAuthState, useDeleteUser, useSignOut } from 'react-firebase-hooks/auth'
 
@@ -22,15 +22,16 @@ const AuthProvider: FC<ReactNodeChildren> = ({ children }) => {
 
   useDisplayToastAfterSignedIn(currentUser)
 
-  const signIn = useCallback(() => {
+  const signIn = useCallback(async () => {
     setSignInLoading(true)
 
-    setPersistence(auth, browserLocalPersistence)
-      .then(() => signInWithRedirect(auth, new GoogleAuthProvider()))
-      .catch((e) => {
-        if (e instanceof Error) setSignInError(e)
-      })
-      .finally(() => setSignInLoading(false))
+    try {
+      await signInWithRedirect(auth, new GoogleAuthProvider())
+    } catch (e) {
+      if (e instanceof Error) setSignInError(e)
+    } finally {
+      setSignInLoading(false)
+    }
   }, [])
 
   const deleteAccount = useCallback(async () => {

--- a/src/types/contexts/authContextType.ts
+++ b/src/types/contexts/authContextType.ts
@@ -2,7 +2,7 @@ import { AuthError, User } from 'firebase/auth'
 
 type AuthContextType = {
   currentUser: User | null | undefined
-  signIn: () => void
+  signIn: () => Promise<void> | void
   signOut: () => Promise<boolean> | void
   deleteAccount: () => Promise<void> | void
   loading: boolean


### PR DESCRIPTION
## Issue
- https://github.com/yuma-matsui/tasting_note_front/issues/299

## What
- サインイン関数内で呼び出していたsetPersistenceを削除した

## Why
- react-firebase-hooksを使用する場合にsetPersistenceが不要になるため
- safariでログインができないバグの原因になっている可能性があるため