### PR TITLE
チェックボックスを制限なく押せてしまうバグを修正した

### DIFF
--- a/src/components/atoms/inputs/TastingSheetCheckBox.tsx
+++ b/src/components/atoms/inputs/TastingSheetCheckBox.tsx
@@ -22,11 +22,11 @@ const TastingSheetCheckBox: FC<TastingSheetCheckBoxProps> = memo(
           id={id}
           value={value}
           disabled={disabled}
+          readOnly
           {...register(name, {
             validate: getValidationMethod(getValues(name))
           })}
           className={className}
-          onChange={() => {}}
         />
         <span className="label-text ml-2">{label ?? value}</span>
       </label>

--- a/src/components/molecules/modals/BaseModal.tsx
+++ b/src/components/molecules/modals/BaseModal.tsx
@@ -4,7 +4,7 @@ import { BaseModalProps } from '../../../types'
 
 const BaseModal: FC<BaseModalProps> = memo(({ text, leftButton, rightButton, visible }) => (
   <>
-    <input type="checkbox" className="modal-toggle" checked={visible} onChange={() => {}} />
+    <input type="checkbox" className="modal-toggle" checked={visible} readOnly />
     <div className="modal">
       <div className="modal-box mx-0">
         <p>{text}</p>

--- a/src/components/organisms/TastingSheetSearchSideBar.tsx
+++ b/src/components/organisms/TastingSheetSearchSideBar.tsx
@@ -7,7 +7,7 @@ const TastingSheetSearchSideBar: FC<{
   onClickToggleSideBar: () => void
 }> = memo(({ sideBarContent, children, visible, onClickToggleSideBar }) => (
   <div className="drawer">
-    <input type="checkbox" className="drawer-toggle" checked={visible} onChange={() => {}} />
+    <input type="checkbox" className="drawer-toggle" checked={visible} readOnly />
     <div className="drawer-content hidden-scrollbar">{children}</div>
     <div className="drawer-side">
       <input type="button" className="drawer-overlay" onClick={onClickToggleSideBar} />


### PR DESCRIPTION
## What
- 不要なonChangeプロパティを削除してreadOnlyに置き換えた

## Why
- ChcckBoxコンポーネントのテストを書いた際にコンポーネントに不要なonChageを与えてしまい、それが原因でバグが発生していたため